### PR TITLE
[WIP] Use astropy and restructure

### DIFF
--- a/galstreams/config.py
+++ b/galstreams/config.py
@@ -1,0 +1,13 @@
+# Third-party
+from astropy.coordinates import Galactocentric, CartesianDifferential
+import astropy.units as u
+
+config = dict()
+config['galcen_distance'] = 8.1 * u.kpc
+config['galcen_v_sun'] = [11.1, 232.24, 7.25] * u.km/u.s
+config['z_sun'] = 27 * u.pc
+
+def get_galactocentric_frame():
+    return Galactocentric(
+        galcen_distance=config['galcen_distance'],
+        galcen_vsun=CartesianDifferential(config['galcen_v_sun']))

--- a/galstreams/config.py
+++ b/galstreams/config.py
@@ -11,3 +11,7 @@ def get_galactocentric_frame():
     return Galactocentric(
         galcen_distance=config['galcen_distance'],
         galcen_vsun=CartesianDifferential(config['galcen_v_sun']))
+
+
+# Default frame for showing:
+config['default_frame'] = 'icrs'

--- a/galstreams/footprint.py
+++ b/galstreams/footprint.py
@@ -4,62 +4,85 @@ import astropy.units as u
 import numpy as np
 from spherical_geometry.polygon import SingleSphericalPolygon
 
+from .config import config
 from .random import get_uniform_spherical_angles
 
 class StreamFootprint:
 
-    @u.quantity_input(distance=u.kpc)
-    def __init__(self, name, poly, frame='icrs', distance=None):
-        """TODO: describe
+    def __init__(self, name, poly, frame=None):
+        """Represents the sky footprint of a given stellar stream.
 
         Parameters
         ----------
         name : str
-        polygon : `spherical_geometry.SphericalPolygon`
+            The stream name.
+        polygon : `~astropy.units.Quantity`, `~spherical_geometry.SphericalPolygon`
+            Either an astropy quantity object (with angular units) specifying
+            the vertices of a spherical polygon, or a spherical polygon
+            instance.
         frame : `astropy.coordinates.BaseCoordinateFrame` subclass instance (optional)
-            Default is ICRS.
+            If not specified, the default is taken from the config settings.
         """
 
         self.name = str(name)
-        self.sname = self.name[:8] # TODO: ???
 
-        # TODO: validate polygon. Can be list of vertices, or object
+        # Validate input polygon. Can be a set of vertices, or an object
+        if not isinstance(poly, SingleSphericalPolygon):
+            poly = u.Quantity(poly)
+            if poly.ndim != 2 or poly.shape[1] != 2:
+                raise ValueError("Invalid shape for polygon vertices {}. "
+                                 "Expected something like (N, 2) where N is "
+                                 "the number of vertices.".format(poly.shape))
+            poly = SingleSphericalPolygon.from_lonlat(
+                poly[:, 0].to_value(u.deg), poly[:, 1].to_value(u.deg),
+                degrees=True)
+
         self.poly = poly
 
-        if isinstance(frame, str):
-            frame = co.frame_transform_graph.lookup_name(frame)
-        self.frame = frame
+        # If no frame is specified, assume that the input polygon is in a frame
+        # specified in the configuration.
+        if frame is None:
+            frame = config['default_frame']
 
-        if isinstance(self.frame, co.Galactocentric) and distance is None:
-            raise ValueError("TODO")
+        elif hasattr(frame, 'frame'): # if a SkyCoord instance
+            frame = frame.frame
+
+        if not isinstance(frame, co.BaseCoordinateFrame):
+            raise ValueError("Input coordinate frame must be an astropy "
+                             "coordinates frame subclass *instance*, not a "
+                             "'{}'".format(frame.__class__.__name__))
+        self.frame = frame
 
         # Store an internal ICRS representation of the footprint
         lon, lat = self.poly.to_lonlat()
-        if distance is not None:
-            poly_c = co.SkyCoord(lon * u.deg, lat * u.deg,
-                                 distance=distance,
-                                 frame=self.frame)
-        else:
-            poly_c = co.SkyCoord(lon * u.deg, lat * u.deg,
-                                 frame=self.frame)
-        self._poly_c = poly_c
-
-        # Store ICRS poly in cache by default (this triggers the caching):
-        self.get_polygon(frame=co.ICRS)
+        self._poly_c = co.SkyCoord(lon * u.deg, lat * u.deg,
+                                   frame=self.frame)
 
     def from_corners(self, corners):
         """ TODO: """
         pass
 
-    def get_polygon(self, frame='icrs'):
-        """TODO:
+    def from_galactocentric(self, name, poly_c, frame=None):
+        """ TODO: """
+        pass
+
+    def get_polygon(self, frame=None):
+        """Get a ``SingleSphericalPolygon`` object in the specified coordinate
+        frame to represent the footprint.
 
         Parameters
         ----------
-        frame : str, `~astropy.coordinates.BaseCoordinateFrame`
+        frame : `astropy.coordinates.BaseCoordinateFrame` subclass instance (optional)
+            If not specified, the default is taken from the config settings.
+
+        Returns
+        -------
+        poly : ``spherical_geometry.SingleSphericalPolygon``
+            The polygon object.
+
         """
-        if not isinstance(frame, str):
-            frame = frame.name
+        if frame is None:
+            frame = config['default_frame']
 
         poly_c = self._poly_c.transform_to(frame)
         poly = SingleSphericalPolygon.from_lonlat(
@@ -68,7 +91,23 @@ class StreamFootprint:
 
         return poly
 
-    def get_midpoint(self, frame='icrs'):
+    def get_sky_center(self, frame=None):
+        """Estimate the central point of the polygon
+
+        This estimate will become worse when the number of vertices along the
+        polygon is small.
+
+        Parameters
+        ----------
+        frame : `astropy.coordinates.BaseCoordinateFrame` subclass instance (optional)
+            If not specified, the default is taken from the config settings.
+
+        Returns
+        -------
+        midpt : `~astropy.coordinates.SkyCoord`
+            The coordinates of the polygon center.
+
+        """
         poly = self.get_polygon(frame)
 
         midpt = co.CartesianRepresentation(*np.mean(poly.points, axis=0)*u.kpc)\
@@ -76,8 +115,35 @@ class StreamFootprint:
 
         return co.SkyCoord(midpt, frame=frame)
 
-    def get_random_points(self, size=1024, frame='icrs', random_state=None,
+    def get_random_points(self, size=1024, frame=None, random_state=None,
                           wrap_angle=360*u.deg, max_niter=128):
+        """Generate uniform random points throughout the stream footprint
+
+        Parameters
+        ----------
+        size : int (optional)
+            The number of points to generate.
+        frame : `astropy.coordinates.BaseCoordinateFrame` subclass instance (optional)
+            The coordinate frame to generate points in.
+        random_state : `numpy.random.RandomState` (optional)
+            A numpy random state object used to control the random number
+            generator and seed.
+        wrap_angle : `~astropy.coordinates.Angle` (optional)
+            The angle to wrap the longitude coordinate at. Specify this if you
+            are having issues with the polygon wrapping around 360 deg.
+        max_niter : int (optional)
+            The maximum number of iterations to use when iteratively generating
+            points within the footprint.
+
+        Returns
+        -------
+        c : `~astropy.coordinates.Skycoord`
+            The coordinates of random points within the sky footprint.
+
+        """
+        if frame is None:
+            frame = config['default_frame']
+
         poly = self.get_polygon(frame=frame)
         verts = np.stack(poly.to_lonlat()).T
         verts[:, 0] = co.Angle(verts[:, 0]*u.deg).wrap_at(wrap_angle).degree
@@ -104,12 +170,30 @@ class StreamFootprint:
                 break
 
         else:
-            raise ValueError("TODO increase max_niter")
+            raise ValueError("Exceeded maximum number of iterations when "
+                             "generating points. Try increasing `max_niter` to "
+                             "something like max_niter=1024 (but note this "
+                             "might take a while to run!).")
 
         rep = co.concatenate_representations(reps)
         return co.SkyCoord(rep[:size], frame=frame)
 
-    def contains_coord(self, c):
+    def contains_coords(self, c):
+        """Check whether the input coordinate or coordinates are inside of the
+        stream footprint.
+
+        Parameters
+        ----------
+        c : `~astropy.coordinates.SkyCoord`
+            Either a scalar coordinate or a set of coordinates to check.
+
+        Returns
+        -------
+        in_footprint : bool, `numpy.ndarray`
+            Either a boolean (for scalar input) or a boolean array (for
+            multiple coordinates) specifying which of the input coordinates are
+            inside of the stream footprint.
+        """
         if isinstance(c, co.BaseRepresentation):
             poly = self.get_polygon()
             rep = c.represent_as(co.SphericalRepresentation)
@@ -128,9 +212,33 @@ class StreamFootprint:
                                     rep.lat.degree)]
             return np.array(mask)
 
-    def plot_polygon(self, frame='icrs', ax=None,
+    def plot_polygon(self, frame=None, ax=None,
                      wrap_angle=360*u.deg, autolim=True, **kwargs):
-        """TODO"""
+        """Plot the footprint polygon
+
+        Parameters
+        ----------
+        frame : `~astropy.coordinates.BaseCoordinateFrame` subclass instance (optional)
+            The coordinate frame to generate points in.
+        ax : `~matplotlib.axes.Axes` (optional)
+            The matplotlib axes object to plot on. If not specified, this will
+            plot on the current axes object.
+        wrap_angle : `~astropy.coordinates.Angle` (optional)
+            The angle to wrap the longitude coordinate at. Specify this if you
+            are having issues with the polygon wrapping around 360 deg.
+        autolim : bool (optional)
+            Determine and set the axes limits automatically to show the whole
+            polygon.
+        **kwargs
+            All other keyword arguments are passed to
+            `~matplotlib.patches.Polygon`.
+
+        Returns
+        -------
+        fig : `~matplotlib.figure.Figure`
+        ax : `~matplotlib.axes.Axes`
+        
+        """
         import matplotlib as mpl
 
         poly = self.get_polygon(frame=frame)
@@ -139,12 +247,12 @@ class StreamFootprint:
 
         if ax is None:
             import matplotlib.pyplot as plt
-            fig, ax = plt.subplots()
-        else:
-            fig = ax.figure
+            ax = plt.gca()
 
-        # Detect if the polygon is mangled by wrapping issues by looking
-        # for discontinuous jumps of >120 degrees in successive points
+        fig = ax.figure
+
+        # TODO: Detect if the polygon is mangled by wrapping issues by looking
+        # for discontinuous jumps of, e.g., >120 degrees in successive points
         # - see APW's notebook Galstreams.ipynb
         if np.any(np.abs(np.diff(verts[:, 0])) > 120):
             # TODO: for now, raise a warning

--- a/galstreams/footprint.py
+++ b/galstreams/footprint.py
@@ -1,0 +1,169 @@
+# Third-party
+import astropy.coordinates as co
+import astropy.units as u
+import numpy as np
+from spherical_geometry.polygon import SingleSphericalPolygon
+
+from .random import get_uniform_spherical_angles
+
+class StreamFootprint:
+
+    @u.quantity_input(distance=u.kpc)
+    def __init__(self, name, poly, frame='icrs', distance=None):
+        """TODO: describe
+
+        Parameters
+        ----------
+        name : str
+        polygon : `spherical_geometry.SphericalPolygon`
+        frame : `astropy.coordinates.BaseCoordinateFrame` subclass instance (optional)
+            Default is ICRS.
+        """
+
+        self.name = str(name)
+        self.sname = self.name[:8] # TODO: ???
+
+        # TODO: validate polygon. Can be list of vertices, or object
+        self.poly = poly
+
+        if isinstance(frame, str):
+            frame = co.frame_transform_graph.lookup_name(frame)
+        self.frame = frame
+
+        if isinstance(self.frame, co.Galactocentric) and distance is None:
+            raise ValueError("TODO")
+
+        # Store an internal ICRS representation of the footprint
+        lon, lat = self.poly.to_lonlat()
+        if distance is not None:
+            poly_c = co.SkyCoord(lon * u.deg, lat * u.deg,
+                                 distance=distance,
+                                 frame=self.frame)
+        else:
+            poly_c = co.SkyCoord(lon * u.deg, lat * u.deg,
+                                 frame=self.frame)
+        self._poly_c = poly_c
+
+        # Store ICRS poly in cache by default (this triggers the caching):
+        self.get_polygon(frame=co.ICRS)
+
+    def from_corners(self, corners):
+        """ TODO: """
+        pass
+
+    def get_polygon(self, frame='icrs'):
+        """TODO:
+
+        Parameters
+        ----------
+        frame : str, `~astropy.coordinates.BaseCoordinateFrame`
+        """
+        if not isinstance(frame, str):
+            frame = frame.name
+
+        poly_c = self._poly_c.transform_to(frame)
+        poly = SingleSphericalPolygon.from_lonlat(
+            poly_c.spherical.lon.degree,
+            poly_c.spherical.lat.degree)
+
+        return poly
+
+    def get_midpoint(self, frame='icrs'):
+        poly = self.get_polygon(frame)
+
+        midpt = co.CartesianRepresentation(*np.mean(poly.points, axis=0)*u.kpc)\
+            .represent_as(co.UnitSphericalRepresentation)
+
+        return co.SkyCoord(midpt, frame=frame)
+
+    def get_random_points(self, size=1024, frame='icrs', random_state=None,
+                          wrap_angle=360*u.deg, max_niter=128):
+        poly = self.get_polygon(frame=frame)
+        verts = np.stack(poly.to_lonlat()).T
+        verts[:, 0] = co.Angle(verts[:, 0]*u.deg).wrap_at(wrap_angle).degree
+
+        lon_lim = [verts[:, 0].min(), verts[:, 0].max()] * u.deg
+        lat_lim = [verts[:, 1].min(), verts[:, 1].max()] * u.deg
+
+        random_size = 4 * size # MAGIC NUMBER
+        N = 0
+        niter = 0
+        reps = []
+        while niter < max_niter:
+            random_size = 2 * random_size
+            rep = get_uniform_spherical_angles(size=random_size,
+                                               lon_lim=lon_lim,
+                                               lat_lim=lat_lim,
+                                               random_state=random_state)
+            c = co.SkyCoord(rep, frame=frame)
+            mask = self.contains_coord(c)
+            reps.append(rep[mask])
+            N += mask.sum()
+
+            if N >= size:
+                break
+
+        else:
+            raise ValueError("TODO increase max_niter")
+
+        rep = co.concatenate_representations(reps)
+        return co.SkyCoord(rep[:size], frame=frame)
+
+    def contains_coord(self, c):
+        if isinstance(c, co.BaseRepresentation):
+            poly = self.get_polygon()
+            rep = c.represent_as(co.SphericalRepresentation)
+        else:
+            c = co.SkyCoord(c)
+            poly = self.get_polygon(frame=c.frame)
+            rep = c.spherical
+
+        if c.isscalar:
+            return poly.contains_lonlat(rep.lon.degree,
+                                        rep.lat.degree)
+
+        else:
+            mask = [poly.contains_lonlat(x, y)
+                    for x, y in zip(rep.lon.degree,
+                                    rep.lat.degree)]
+            return np.array(mask)
+
+    def plot_polygon(self, frame='icrs', ax=None,
+                     wrap_angle=360*u.deg, autolim=True, **kwargs):
+        """TODO"""
+        import matplotlib as mpl
+
+        poly = self.get_polygon(frame=frame)
+        verts = np.stack(poly.to_lonlat()).T
+        verts[:, 0] = co.Angle(verts[:, 0]*u.deg).wrap_at(wrap_angle).degree
+
+        if ax is None:
+            import matplotlib.pyplot as plt
+            fig, ax = plt.subplots()
+        else:
+            fig = ax.figure
+
+        # Detect if the polygon is mangled by wrapping issues by looking
+        # for discontinuous jumps of >120 degrees in successive points
+        # - see APW's notebook Galstreams.ipynb
+        if np.any(np.abs(np.diff(verts[:, 0])) > 120):
+            # TODO: for now, raise a warning
+            pass
+
+        poly_patch = mpl.patches.Polygon(verts, **kwargs)
+        ax.add_patch(poly_patch)
+
+        if autolim:
+            h = 0.05 # make limits 5% larger than span
+            xlim = (verts[:, 0].min(), verts[:, 0].max())
+            span = xlim[1]-xlim[0]
+            xlim = (xlim[1] + h*span, xlim[0] - h*span)
+
+            ylim = (verts[:, 1].min(), verts[:, 1].max())
+            span = ylim[1]-ylim[0]
+            ylim = (ylim[0] - h*span, ylim[1] + h*span)
+
+            ax.set_xlim(xlim)
+            ax.set_ylim(ylim)
+
+        return fig, ax

--- a/galstreams/random.py
+++ b/galstreams/random.py
@@ -10,19 +10,23 @@ __all__ = ['get_uniform_spherical_angles', 'get_uniform_sphere']
 @u.quantity_input(lon_lim=u.deg, lat_lim=u.deg)
 def get_uniform_spherical_angles(size=1,
                                  lon_lim=[0., 360]*u.deg,
-                                 lat_lim=[-90., 90]*u.deg):
+                                 lat_lim=[-90., 90]*u.deg,
+                                 random_state=None):
     """Generate uniform random positions on the sphere
 
     Parameters
     ----------
     size : int
         The number of points to generate.
-    lon_lim : `~astropy.units.Quantity`
+    lon_lim : `~astropy.units.Quantity` (optional)
         The longitude limits to generate as an astropy Angle object or Quantity
         with angular units.
-    lat_lim : `~astropy.units.Quantity`
+    lat_lim : `~astropy.units.Quantity` (optional)
         The latitude limits to generate as an astropy Angle object or Quantity
         with angular units.
+    random_state : `numpy.random.RandomState` (optional)
+        A numpy random state object used to control the random number generator
+        and seed.
 
     Returns
     -------
@@ -30,22 +34,26 @@ def get_uniform_spherical_angles(size=1,
         An astropy unit spherical representation object containing the random
         spherical positions.
     """
+    if random_state is None:
+        random_state = np.random
 
     lon = np.random.uniform(lon_lim[0].value,
                             lon_lim[1].value,
                             size) * lon_lim.unit
 
     K = np.sin(lat_lim[1]) - np.sin(lat_lim[0])
-    arg = K * np.random.uniform(size=size) + np.sin(lat_lim[0])
+    arg = K * random_state.uniform(size=size) + np.sin(lat_lim[0])
     lat = np.arcsin(arg)
 
     return coord.UnitSphericalRepresentation(lon, lat)
+
 
 @u.quantity_input(lon_lim=u.deg, lat_lim=u.deg, dist_lim=[u.one, u.pc])
 def get_uniform_sphere(size,
                        lon_lim=[0., 360]*u.deg,
                        lat_lim=[-90., 90]*u.deg,
-                       dist_lim=[0, 1.]*u.one):
+                       dist_lim=[0, 1.]*u.one,
+                       random_state=None):
     """Generate uniform random positions inside a spherical volume.
 
     i.e. this can be used to generate points uniformly distributed through a
@@ -64,6 +72,9 @@ def get_uniform_sphere(size,
     dist_lim : `~astropy.units.Quantity`
         The distance limits to generate as an astropy Quantity, either
         dimensionless or with length units.
+    random_state : `numpy.random.RandomState` (optional)
+        A numpy random state object used to control the random number generator
+        and seed.
 
     Returns
     -------
@@ -71,15 +82,18 @@ def get_uniform_sphere(size,
         An astropy spherical representation object containing the random
         spherical positions.
     """
-
-    # R distributed as R^2
-    r = np.cbrt(np.random.uniform(dist_lim[0].value**3,
-                                  dist_lim[1].value**3,
-                                  size=size)) * dist_lim.unit
+    if random_state is None:
+        random_state = np.random
 
     rep = get_uniform_spherical_angles(size=size,
                                        lon_lim=lon_lim,
-                                       lat_lim=lat_lim)
+                                       lat_lim=lat_lim,
+                                       random_state=random_state)
+
+    # R distributed as R^2
+    r = np.cbrt(random_state.uniform(dist_lim[0].value**3,
+                                     dist_lim[1].value**3,
+                                     size=size)) * dist_lim.unit
 
     return coord.SphericalRepresentation(lon=rep.lon,
                                          lat=rep.lat,

--- a/galstreams/random.py
+++ b/galstreams/random.py
@@ -1,0 +1,86 @@
+
+import astropy.coordinates as coord
+import astropy.units as u
+import numpy as np
+
+
+__all__ = ['get_uniform_spherical_angles', 'get_uniform_sphere']
+
+
+@u.quantity_input(lon_lim=u.deg, lat_lim=u.deg)
+def get_uniform_spherical_angles(size=1,
+                                 lon_lim=[0., 360]*u.deg,
+                                 lat_lim=[-90., 90]*u.deg):
+    """Generate uniform random positions on the sphere
+
+    Parameters
+    ----------
+    size : int
+        The number of points to generate.
+    lon_lim : `~astropy.units.Quantity`
+        The longitude limits to generate as an astropy Angle object or Quantity
+        with angular units.
+    lat_lim : `~astropy.units.Quantity`
+        The latitude limits to generate as an astropy Angle object or Quantity
+        with angular units.
+
+    Returns
+    -------
+    representation : `~astropy.coordinates.UnitSphericalRepresentation`
+        An astropy unit spherical representation object containing the random
+        spherical positions.
+    """
+
+    lon = np.random.uniform(lon_lim[0].value,
+                            lon_lim[1].value,
+                            size) * lon_lim.unit
+
+    K = np.sin(lat_lim[1]) - np.sin(lat_lim[0])
+    arg = K * np.random.uniform(size=size) + np.sin(lat_lim[0])
+    lat = np.arcsin(arg)
+
+    return coord.UnitSphericalRepresentation(lon, lat)
+
+@u.quantity_input(lon_lim=u.deg, lat_lim=u.deg, dist_lim=[u.one, u.pc])
+def get_uniform_sphere(size,
+                       lon_lim=[0., 360]*u.deg,
+                       lat_lim=[-90., 90]*u.deg,
+                       dist_lim=[0, 1.]*u.one):
+    """Generate uniform random positions inside a spherical volume.
+
+    i.e. this can be used to generate points uniformly distributed through a
+    spherical annulus by specifying the distance limits.
+
+    Parameters
+    ----------
+    size : int
+        The number of points to generate.
+    lon_lim : `~astropy.units.Quantity`
+        The longitude limits to generate as an astropy Angle object or Quantity
+        with angular units.
+    lat_lim : `~astropy.units.Quantity`
+        The latitude limits to generate as an astropy Angle object or Quantity
+        with angular units.
+    dist_lim : `~astropy.units.Quantity`
+        The distance limits to generate as an astropy Quantity, either
+        dimensionless or with length units.
+
+    Returns
+    -------
+    representation : `~astropy.coordinates.SphericalRepresentation`
+        An astropy spherical representation object containing the random
+        spherical positions.
+    """
+
+    # R distributed as R^2
+    r = np.cbrt(np.random.uniform(dist_lim[0].value**3,
+                                  dist_lim[1].value**3,
+                                  size=size)) * dist_lim.unit
+
+    rep = get_uniform_spherical_angles(size=size,
+                                       lon_lim=lon_lim,
+                                       lat_lim=lat_lim)
+
+    return coord.SphericalRepresentation(lon=rep.lon,
+                                         lat=rep.lat,
+                                         distance=r)


### PR DESCRIPTION
Hey @cmateu! This is nowhere near done, but I wanted to open this to show that I have at least been working on some aspects of an update. But before I do more (since this is already a pretty big change to the code!), I wanted to bring up a few ideas I had to hear your thoughts.

I started thinking about what information I want for a given stream, and decided that what I really want for each stream is (1) a mean track (along the sky, possibly with width, and possibly also with distance, proper motion, RV information when that exists), (2) a heliocentric sky footprint, and (3) a great circle coordinate frame that tries to put the track at lat=0. So I'm now thinking that instead of providing footprints based on great circles or lon/lat ranges (lesson learned from the old Pal 5 and GD-1 tracks?), perhaps we could go back to each stream and produce an approximate sky track and associated footprint. Then, for each stream, if it has a defined coordinate system already (e.g., GD-1), we use that, otherwise we determine a GC frame based on the track. 

So, with those ideas in mind, my plan was to:
1. Restructure the `(Stream)Footprint` class to support doing operations with the footprint (like, testing whether coordinates lie within a stream footprint, etc.).
2. Go stream-by-stream and extract tracks from papers by either using provided tracks or doing it by eye from plots. As a test, I did this for Phoenix and Carl's 2009 streams (Acheron, Lethe, ...) : for Phoenix (top plot), the orange points are the over-densities reported, and the blue is a polynomial fit to those over-densities. For Carl's streams (bottom plot), I picked out a few locations along the streams and fit a polynomial track.
![image](https://user-images.githubusercontent.com/583379/55912605-e7e14400-5b97-11e9-94da-6e3f1dafeff1.png)
![image](https://user-images.githubusercontent.com/583379/55912614-ec0d6180-5b97-11e9-889a-c7236c163205.png)
3. Change the data files so that each stream has a *track* instead of a specification of a footprint or coordinate frame.
4. Produce a master table with metadata for each stream, e.g., mean distance, metallicity, age, etc. (maybe you have this already but I started a [google sheet](https://docs.google.com/spreadsheets/d/1wW3OJTmDBQpbh9dsMD-63zjMd6n8BVYQPnDafv2qelQ/edit#gid=0) in case not).

From the above, we could easily generate the data files you like to have for topcat, so I think it will be "backwards-compatible" in that sense, even if the code structure changes.

Thoughts? This feels like a lot of work, but it is what I've always wanted. Let me know also if you disagree on these ideas :)