### PR TITLE
Use GreatCircleICRSFrame.from_pole_ra0

### DIFF
--- a/galstreams/__init__.py
+++ b/galstreams/__init__.py
@@ -834,7 +834,7 @@ class Track6D:
       self.mid_pole = ac.SkyCoord(**x)
 
       #Set up stream's coordinate frame
-      self.stream_frame = gc.GreatCircleICRSFrame(pole=self.mid_pole, ra0=self.mid_point.icrs.ra)
+      self.stream_frame = gc.GreatCircleICRSFrame.from_pole_ra0(pole=self.mid_pole, ra0=self.mid_point.icrs.ra)
 
       #Compute and store polygon vertices
       self.poly_sc = self.create_sky_polygon_footprint_from_track(width=1*u.deg)


### PR DESCRIPTION
Gaia's GreatCircleICRSFrame default initializer no longer supports the (pole, ra0) method. The `from_pole_ra0` method is required.