### PR TITLE
Update codecov-action version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,5 +38,6 @@ jobs:
         python -m pytest -ra --cov --cov-report=xml --cov-report=term --durations=20
 
     - name: Upload coverage report
-      uses: codecov/codecov-action@v4.1.0
-
+      uses: codecov/codecov-action@v7
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Ensure GitHub actions is running the newest version of codecov uploads