### PR TITLE
Use packaging.version for robust gala version comparison. Fixes #58

### DIFF
--- a/galstreams/core.py
+++ b/galstreams/core.py
@@ -10,6 +10,7 @@ import astropy.units as u
 import gala
 import gala.coordinates as gc
 import gala.dynamics as gd
+from packaging import version
 
 
 #---------------------------------
@@ -860,7 +861,7 @@ class Track6D:
 
 
       #Set up stream's coordinate frame
-      if np.float64(gala.__version__[:3])<=1.4:
+      if version.parse(gala.__version__)<=version.parse("1.4"):
          self.stream_frame = gc.GreatCircleICRSFrame(pole=self.mid_pole, ra0=self.mid_point.icrs.ra)  
       else:  
          self.stream_frame = gc.GreatCircleICRSFrame.from_pole_ra0(


### PR DESCRIPTION
Simple version comparison for gala in [`core.py`](galstreams/core.py) breaks for versions 1.10 and (future) higher ones. Used package.version to fix it. Fixes issue #58 